### PR TITLE
do not crash if unexpected status value

### DIFF
--- a/colab-webapp/src/main/node/app/src/components/cards/CardContentStatus.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/CardContentStatus.tsx
@@ -49,6 +49,10 @@ export function getStatusIconAndColor(status: CardContentStatus): StatusIconAndC
     case 'REJECTED':
       return { icon: 'close', color: 'var(--error-main)' };
   }
+
+  // should never happen,
+  // but whenever there is an unknown value in DB, it does not stupidly crash
+  return { icon: 'pest_control_rodent', color: 'var(--gray-300)' };
 }
 
 export default function CardContentStatusDisplay({
@@ -60,7 +64,7 @@ export default function CardContentStatusDisplay({
 }: CardContentStatusDisplayProps): JSX.Element {
   const i18n = useTranslations();
 
-  const tooltip = i18n.modules.card.settings.statusTooltip(status);
+  const tooltip = i18n.modules.card.settings.statusIs + i18n.modules.card.settings.statuses[status];
 
   if (mode === 'icon') {
     if (status === 'ACTIVE' && !showActive) {

--- a/colab-webapp/src/main/node/app/src/i18n/en.ts
+++ b/colab-webapp/src/main/node/app/src/i18n/en.ts
@@ -5,7 +5,7 @@
  * Licensed under the MIT License
  */
 
-import { CardContentStatus, MessageI18nKey } from 'colab-rest-client';
+import { MessageI18nKey } from 'colab-rest-client';
 
 export const en = {
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -438,8 +438,7 @@ export const en = {
         locked: 'Locked',
         color: 'Color',
         status: 'Status',
-        statusTooltip: (status: CardContentStatus) =>
-          `Status: ${en.modules.card.settings.statuses[status].toLocaleLowerCase('en')}`,
+        statusIs: 'Status: ',
         statuses: {
           ACTIVE: 'Active',
           PREPARATION: 'In preparation',

--- a/colab-webapp/src/main/node/app/src/i18n/fr.ts
+++ b/colab-webapp/src/main/node/app/src/i18n/fr.ts
@@ -5,7 +5,7 @@
  * Licensed under the MIT License
  */
 
-import { CardContentStatus, MessageI18nKey } from 'colab-rest-client';
+import { MessageI18nKey } from 'colab-rest-client';
 import { ColabTranslations } from './I18nContext';
 
 export const fr: ColabTranslations = {
@@ -444,8 +444,7 @@ export const fr: ColabTranslations = {
         locked: 'Verrouillé',
         color: 'Couleur',
         status: 'Statut',
-        statusTooltip: (status: CardContentStatus) =>
-          `Statut: ${fr.modules.card.settings.statuses[status].toLocaleLowerCase('fr')}`,
+        statusIs: 'Statut: ',
         statuses: {
           ACTIVE: 'Actif',
           PREPARATION: 'En préparation',


### PR DESCRIPTION
Prevents a card of not showing if the status is null.
There is still a problem if there is an unexpected value, it behaves as the user does not have privilege access.