### PR TITLE
Display quick wins

### DIFF
--- a/colab-webapp/src/main/node/app/public/index.html
+++ b/colab-webapp/src/main/node/app/public/index.html
@@ -8,19 +8,19 @@
       @font-face {
         font-family: 'Public Sans';
         font-style: normal;
-        src: url('../../fonts/PublicSans[wght].ttf') format('truetype');
+        src: url('./fonts/PublicSans[wght].ttf') format('truetype');
       }
 
       @font-face {
         font-family: 'Public Sans Italic';
         font-style: normal;
-        src: url('../../fonts/PublicSans-Italic[wght].ttf') format('truetype');
+        src: url('./fonts/PublicSans-Italic[wght].ttf') format('truetype');
       }
 
       @font-face {
         font-family: 'Material Symbols Outlined';
         font-style: normal;
-        src: url('../../fonts/MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].woff2') format('woff2');
+        src: url('./fonts/MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].woff2') format('woff2');
         font-display: block;
       }
 

--- a/colab-webapp/src/main/node/app/src/components/cards/CardContentStatusDisplay.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/CardContentStatusDisplay.tsx
@@ -12,7 +12,7 @@ import useTranslations from '../../i18n/I18nContext';
 import { MaterialIconsType } from '../../styling/IconType';
 import { space_xs, text_xs } from '../../styling/style';
 import Badge from '../common/element/Badge';
-import Icon from '../common/layout/Icon';
+import Icon, { IconSize } from '../common/layout/Icon';
 
 // -------------------------------------------------------------------------------------------------
 // styles
@@ -31,6 +31,7 @@ interface CardContentStatusDisplayProps {
   status: StatusType;
   kind: 'icon_only' | 'outlined' | 'solid';
   showEmpty?: boolean;
+  iconSize?: keyof typeof IconSize;
   className?: string;
 }
 
@@ -38,13 +39,13 @@ export default function CardContentStatusDisplay({
   status,
   kind,
   showEmpty = false,
+  iconSize = 'xs',
   className,
 }: CardContentStatusDisplayProps): JSX.Element {
   const text = useText(status);
   const { icon, color } = getIconAndColor(status);
   const tooltip = useTooltip(status);
 
-  const iconSize = 'xs';
   const textStyle = text_xs;
 
   if (status == null) {

--- a/colab-webapp/src/main/node/app/src/components/cards/CardEditor.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/CardEditor.tsx
@@ -113,7 +113,12 @@ export default function CardEditor({ card, cardContent }: CardEditorProps): JSX.
     return (
       <Flex direction="column" align="stretch" className={css({ height: '100%', width: '100%' })}>
         <Dndwrapper cards={subCards}>
-          <CardEditorHeader card={card} cardContent={cardContent} readOnly={readOnly} />
+          <CardEditorHeader
+            card={card}
+            cardContent={cardContent}
+            readOnly={readOnly}
+            setSplitterPlace={setSplitterPlace}
+          />
           <Flex direction="row" grow={1} align="stretch" className={css({ overflow: 'auto' })}>
             <SideCollapsibleCtx.Provider
               value={{
@@ -138,7 +143,6 @@ export default function CardEditor({ card, cardContent }: CardEditorProps): JSX.
                       <ReflexElement
                         className={'top-panel ' + css({ display: 'flex' })}
                         resizeWidth={false}
-                        minSize={65}
                         flex={splitterPlace === 'BOTTOM' ? 1 : splitterPlace === 'TOP' ? 0 : 0.5}
                       >
                         {/* ******************************** DELIVERABLE ******************************** */}
@@ -158,7 +162,6 @@ export default function CardEditor({ card, cardContent }: CardEditorProps): JSX.
                       <ReflexElement
                         className={'bottom-panel ' + css({ display: 'flex', minHeight: '44px' })}
                         resizeWidth={false}
-                        minSize={44}
                       >
                         {/* ******************************** SUB CARDS ******************************** */}
                         <CardEditorSubCards

--- a/colab-webapp/src/main/node/app/src/components/cards/CardEditorHeader.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/CardEditorHeader.tsx
@@ -170,7 +170,7 @@ export default function CardEditorHeader({
 
           <Flex align="center">
             <IconButton
-              title="contentOnly"
+              title={i18n.modules.card.editor.contentOnly}
               icon={'subtitles'}
               kind="ghost"
               iconSize="xs"
@@ -180,7 +180,7 @@ export default function CardEditorHeader({
               className={css({ marginRight: space_sm, backgroundColor: 'transparent' })}
             />
             <IconButton
-              title="splitted"
+              title={i18n.modules.card.editor.split}
               icon={'space_dashboard'}
               kind="ghost"
               iconSize="xs"
@@ -190,7 +190,7 @@ export default function CardEditorHeader({
               className={css({ marginRight: space_sm, backgroundColor: 'transparent' })}
             />
             <IconButton
-              title="cardsOnly"
+              title={i18n.modules.card.editor.cardsOnly}
               icon={'iframe'}
               kind="ghost"
               iconSize="xs"

--- a/colab-webapp/src/main/node/app/src/components/cards/CardEditorHeader.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/CardEditorHeader.tsx
@@ -37,7 +37,7 @@ import ProjectBreadcrumbs from '../projects/ProjectBreadcrumbs';
 import { CardEditorDeletedBanner } from './CardEditorDeletedBanner';
 import { getCardTitle } from './CardTitle';
 import { ProgressBarEditor } from './ProgressBar';
-import StatusDropDown from './StatusDropDown';
+import StatusDropDown, { StatusSubDropDownEntry } from './StatusDropDown';
 import { VariantPager } from './VariantSelector';
 
 interface CardEditorHeaderProps {
@@ -120,22 +120,22 @@ export default function CardEditorHeader({
                 <VariantPager allowCreation={!readOnly} card={card} current={cardContent} />
               </>
             )}
-            <IconButton
-              icon={cardContent.frozen ? 'lock' : 'lock_open'}
-              title={i18n.modules.card.infos.cardLocked}
-              color={'var(--gray-400)'}
-              onClick={() =>
-                dispatch(API.updateCardContent({ ...cardContent, frozen: !cardContent.frozen }))
-              }
-              kind="ghost"
-              className={css({ padding: space_sm, background: 'none' })}
-            />
-            <StatusDropDown
-              value={cardContent.status}
-              readOnly={readOnly}
-              onChange={status => dispatch(API.updateCardContent({ ...cardContent, status }))}
-              kind="outlined"
-            />
+            {cardContent.frozen /* display only if is locked */ && (
+              <Icon
+                icon={'lock'}
+                title={i18n.modules.card.infos.cardLocked}
+                color={'var(--gray-400)'}
+                className={css({ padding: space_sm, background: 'none' })}
+              />
+            )}
+            {cardContent.status != null /* display only if has a status */ && (
+              <StatusDropDown
+                value={cardContent.status}
+                readOnly={readOnly}
+                onChange={status => dispatch(API.updateCardContent({ ...cardContent, status }))}
+                kind="outlined"
+              />
+            )}
           </Flex>
           {currentUser?.admin && tipsConfig.DEBUG.value && (
             <Flex
@@ -196,6 +196,46 @@ export default function CardEditorHeader({
               valueComp={{ value: '', label: '' }}
               buttonClassName={lightIconButtonStyle}
               entries={[
+                {
+                  value: 'changeStatus',
+                  label: (
+                    <StatusSubDropDownEntry
+                      mainLabel={i18n.modules.card.action.changeStatus}
+                      onChange={newStatus => {
+                        dispatch(
+                          API.updateCardContent({
+                            ...cardContent,
+                            status: newStatus ?? null,
+                          }),
+                        );
+                      }}
+                    />
+                  ),
+                  subDropDownButton: true,
+                },
+                {
+                  value: 'changeLock',
+                  label: (
+                    <>
+                      {cardContent.frozen ? (
+                        <>
+                          <Icon icon={'lock_open'} />
+                          {i18n.modules.card.action.unlock}
+                        </>
+                      ) : (
+                        <>
+                          <Icon icon={'lock'} />
+                          {i18n.modules.card.action.lock}
+                        </>
+                      )}
+                    </>
+                  ),
+                  action: () => {
+                    dispatch(
+                      API.updateCardContent({ ...cardContent, frozen: !cardContent.frozen }),
+                    );
+                  },
+                },
                 ...(currentUser?.admin && card.cardTypeId == null
                   ? [
                       {

--- a/colab-webapp/src/main/node/app/src/components/cards/CardEditorHeader.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/CardEditorHeader.tsx
@@ -29,7 +29,7 @@ import Button from '../common/element/Button';
 import DeletionStatusIndicator from '../common/element/DeletionStatusIndicator';
 import IconButton from '../common/element/IconButton';
 import { DiscreetInput } from '../common/element/Input';
-import { TipsCtx, WIPContainer } from '../common/element/Tips';
+import { TipsCtx } from '../common/element/Tips';
 import DropDownMenu, { entryStyle } from '../common/layout/DropDownMenu';
 import Flex from '../common/layout/Flex';
 import Icon from '../common/layout/Icon';
@@ -43,11 +43,13 @@ import { VariantPager } from './VariantSelector';
 interface CardEditorHeaderProps {
   card: Card;
   cardContent: CardContent;
+  setSplitterPlace: React.Dispatch<React.SetStateAction<'TOP' | 'MIDDLE' | 'BOTTOM' | undefined>>;
   readOnly?: boolean;
 }
 export default function CardEditorHeader({
   card,
   cardContent,
+  setSplitterPlace,
   readOnly,
 }: CardEditorHeaderProps): JSX.Element {
   const i18n = useTranslations();
@@ -167,29 +169,36 @@ export default function CardEditorHeader({
           {/* View mode btn *********************************************** */}
 
           <Flex align="center">
-            <WIPContainer>
-              <IconButton
-                title="contentOnly"
-                icon={'subtitles'}
-                kind="ghost"
-                iconSize="xs"
-                className={css({ marginRight: space_sm })}
-              ></IconButton>
-              <IconButton
-                title="Splitted"
-                icon={'space_dashboard'}
-                kind="ghost"
-                iconSize="xs"
-                className={css({ marginRight: space_sm })}
-              ></IconButton>
-              <IconButton
-                title="cardsOnly"
-                icon={'iframe'}
-                kind="ghost"
-                iconSize="xs"
-                className={css({ marginRight: space_sm })}
-              ></IconButton>
-            </WIPContainer>
+            <IconButton
+              title="contentOnly"
+              icon={'subtitles'}
+              kind="ghost"
+              iconSize="xs"
+              onClick={() => {
+                setSplitterPlace('BOTTOM');
+              }}
+              className={css({ marginRight: space_sm, backgroundColor: 'transparent' })}
+            />
+            <IconButton
+              title="splitted"
+              icon={'space_dashboard'}
+              kind="ghost"
+              iconSize="xs"
+              onClick={() => {
+                setSplitterPlace('MIDDLE');
+              }}
+              className={css({ marginRight: space_sm, backgroundColor: 'transparent' })}
+            />
+            <IconButton
+              title="cardsOnly"
+              icon={'iframe'}
+              kind="ghost"
+              iconSize="xs"
+              onClick={() => {
+                setSplitterPlace('TOP');
+              }}
+              className={css({ marginRight: space_sm, backgroundColor: 'transparent' })}
+            />
 
             <DropDownMenu
               icon={'more_vert'}

--- a/colab-webapp/src/main/node/app/src/components/cards/CardThumb.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/CardThumb.tsx
@@ -29,6 +29,7 @@ import { cardColors } from '../../styling/theme';
 import { ColorPicker } from '../common/element/ColorPicker';
 import DeletionStatusIndicator from '../common/element/DeletionStatusIndicator';
 import { DiscreetInput, DiscreetTextArea } from '../common/element/Input';
+import { Link } from '../common/element/Link';
 import { FeaturePreview } from '../common/element/Tips';
 import DropDownMenu from '../common/layout/DropDownMenu';
 import Flex from '../common/layout/Flex';
@@ -132,14 +133,18 @@ export default function CardThumb({
 
   const cardId = card.id;
 
-  const navigateToCb = React.useCallback(() => {
+  const cardPath = React.useMemo(() => {
     const path = `card/${cardId}/v/${variant?.id}`;
     if (location.pathname.match(/(card)\/\d+\/v\/\d+/)) {
-      navigate(`../${path}`);
+      return '../' + path;
     } else {
-      navigate(path);
+      return path;
     }
-  }, [variant, cardId, location.pathname, navigate]);
+  }, [variant, cardId, location.pathname]);
+
+  const navigateToCb = React.useCallback(() => {
+    navigate(cardPath);
+  }, [navigate, cardPath]);
 
   const hasSubCards = (useAndLoadSubCards(variant?.id)?.length || 0) > 0;
   // const currentPathIsSelf = location.pathname.match(new RegExp(`card/${card.id}`)) != null;
@@ -310,11 +315,10 @@ export default function CardThumb({
                             {
                               value: 'edit',
                               label: (
-                                <>
+                                <Link to={cardPath}>
                                   <Icon icon={'edit'} /> {i18n.common.edit}
-                                </>
+                                </Link>
                               ),
-                              action: navigateToCb,
                             },
                             ...(depth === 1
                               ? [

--- a/colab-webapp/src/main/node/app/src/components/cards/CardThumb.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/CardThumb.tsx
@@ -38,7 +38,7 @@ import CardCreator from './CardCreator';
 import CardCreatorAndOrganize from './CardCreatorAndOrganize';
 import CardLayout from './CardLayout';
 import { getCardTitle } from './CardTitle';
-import StatusDropDown from './StatusDropDown';
+import StatusDropDown, { StatusSubDropDownEntry } from './StatusDropDown';
 import SubCardsGrid from './SubCardsGrid';
 import { useIsCardReadOnly } from './cardRightsHooks';
 import Droppable from './dnd/Droppable';
@@ -268,18 +268,20 @@ export default function CardThumb({
                               rows={2}
                             />
                           )}
-                          {depth === 1 && (
-                            <Flex className={css({ margin: '0 ' + space_sm, flexShrink: 0 })}>
-                              <StatusDropDown
-                                value={variant?.status}
-                                readOnly={readOnly}
-                                onChange={status =>
-                                  dispatch(API.updateCardContent({ ...variant!, status }))
-                                }
-                                kind={depth ? 'outlined' : 'icon_only'}
-                              />
-                            </Flex>
-                          )}
+                          {depth === 1 &&
+                            variant?.status != null /* display only if has a status */ && (
+                              <Flex className={css({ margin: '0 ' + space_sm, flexShrink: 0 })}>
+                                <StatusDropDown
+                                  value={variant?.status}
+                                  readOnly={readOnly}
+                                  onChange={status =>
+                                    dispatch(API.updateCardContent({ ...variant!, status }))
+                                  }
+                                  kind={'icon_only'}
+                                  iconSize="xxs"
+                                />
+                              </Flex>
+                            )}
                           {hasVariants && (
                             <span className={cx(oneLineEllipsisStyle, css({ minWidth: '50px' }))}>
                               &#xFE58;
@@ -322,19 +324,24 @@ export default function CardThumb({
                                   },
                                 ]
                               : []),
-                            ...(!isDirectUnderRoot
+                            ...(variant
                               ? [
                                   {
-                                    value: 'moveAbove',
-
+                                    value: 'changeStatus',
                                     label: (
-                                      <>
-                                        <Icon icon={'north'} /> {i18n.common.action.moveAbove}
-                                      </>
+                                      <StatusSubDropDownEntry
+                                        mainLabel={i18n.modules.card.action.changeStatus}
+                                        onChange={newStatus => {
+                                          dispatch(
+                                            API.updateCardContent({
+                                              ...variant,
+                                              status: newStatus ?? null,
+                                            }),
+                                          );
+                                        }}
+                                      />
                                     ),
-                                    action: () => {
-                                      dispatch(API.moveCardAbove(cardId));
-                                    },
+                                    subDropDownButton: true,
                                   },
                                 ]
                               : []),
@@ -352,6 +359,22 @@ export default function CardThumb({
                                 />
                               ),
                             },
+                            ...(!isDirectUnderRoot
+                              ? [
+                                  {
+                                    value: 'moveAbove',
+
+                                    label: (
+                                      <>
+                                        <Icon icon={'north'} /> {i18n.common.action.moveAbove}
+                                      </>
+                                    ),
+                                    action: () => {
+                                      dispatch(API.moveCardAbove(cardId));
+                                    },
+                                  },
+                                ]
+                              : []),
                             {
                               value: 'delete',
                               label: (

--- a/colab-webapp/src/main/node/app/src/components/cards/CardThumb.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/CardThumb.tsx
@@ -307,6 +307,15 @@ export default function CardThumb({
                           buttonClassName={cx(lightIconButtonStyle)}
                           className={css({ alignSelf: depth === 0 ? 'flex-start' : 'center' })}
                           entries={[
+                            {
+                              value: 'edit',
+                              label: (
+                                <>
+                                  <Icon icon={'edit'} /> {i18n.common.edit}
+                                </>
+                              ),
+                              action: navigateToCb,
+                            },
                             ...(depth === 1
                               ? [
                                   {

--- a/colab-webapp/src/main/node/app/src/components/cards/StatusDropDown.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/StatusDropDown.tsx
@@ -71,7 +71,7 @@ export function StatusSubDropDownEntry({
 }): JSX.Element {
   return (
     <DropDownMenu
-      icon="keyboard_double_arrow_left"
+      icon="assignment_turned_in"
       buttonLabel={mainLabel}
       entries={buildEntryForOptions(onChange)}
       idleHoverStyle="BACKGROUND"

--- a/colab-webapp/src/main/node/app/src/components/cards/StatusDropDown.tsx
+++ b/colab-webapp/src/main/node/app/src/components/cards/StatusDropDown.tsx
@@ -9,7 +9,8 @@ import { css, cx } from '@emotion/css';
 import { CardContent } from 'colab-rest-client';
 import React from 'react';
 import { iconButtonStyle, p_xs } from '../../styling/style';
-import DropDownMenu from '../common/layout/DropDownMenu';
+import DropDownMenu, { Entry, entryStyle } from '../common/layout/DropDownMenu';
+import { IconSize } from '../common/layout/Icon';
 import CardContentStatusDisplay from './CardContentStatusDisplay';
 
 const buttonStyle = css({
@@ -23,22 +24,16 @@ const disabledStyle = css({
   opacity: 0.6,
 });
 
-type StatusType = CardContent['status'];
+type StatusType = CardContent['status'] | null;
 
-const options: (StatusType | null)[] = [
-  null,
-  'ACTIVE',
-  'TO_VALIDATE',
-  'VALIDATED',
-  'REJECTED',
-  'ARCHIVED',
-];
+const options: StatusType[] = [null, 'ACTIVE', 'TO_VALIDATE', 'VALIDATED', 'REJECTED', 'ARCHIVED'];
 
 interface StatusDropDownProps {
   value: StatusType;
   readOnly?: boolean;
   onChange: (status: StatusType) => void;
   kind?: 'icon_only' | 'outlined' | 'solid';
+  iconSize?: keyof typeof IconSize;
 }
 
 export default function StatusDropDown({
@@ -46,8 +41,49 @@ export default function StatusDropDown({
   readOnly, // implement me !
   onChange,
   kind = 'outlined',
+  iconSize,
 }: StatusDropDownProps): JSX.Element {
-  const entries = options.map(option => {
+  const entries = buildEntryForOptions(onChange);
+  return (
+    <DropDownMenu
+      buttonLabel={
+        <CardContentStatusDisplay
+          kind={kind}
+          status={value}
+          showEmpty
+          iconSize={iconSize}
+          className={css({ backgroundColor: 'transparent' })}
+        />
+      }
+      valueComp={{ value: '', label: '' }}
+      buttonClassName={cx(iconButtonStyle, p_xs, readOnly ? disabledStyle : buttonStyle)}
+      entries={entries}
+    />
+  );
+}
+
+export function StatusSubDropDownEntry({
+  mainLabel,
+  onChange,
+}: {
+  mainLabel: string;
+  onChange: (status: StatusType) => void;
+}): JSX.Element {
+  return (
+    <DropDownMenu
+      icon="keyboard_double_arrow_left"
+      buttonLabel={mainLabel}
+      entries={buildEntryForOptions(onChange)}
+      idleHoverStyle="BACKGROUND"
+      className={css({ alignItems: 'stretch' })}
+      buttonClassName={entryStyle}
+      direction="left"
+    />
+  );
+}
+
+function buildEntryForOptions(onChange: (Status: StatusType) => void): Entry<string>[] {
+  return options.map(option => {
     return {
       value: option as string,
       label: (
@@ -58,15 +94,9 @@ export default function StatusDropDown({
           className={css({ flexGrow: 1 })}
         />
       ),
-      action: () => onChange(option ?? null),
+      action: () => {
+        onChange(option ?? null);
+      },
     };
   });
-  return (
-    <DropDownMenu
-      buttonLabel={<CardContentStatusDisplay kind={kind} status={value} showEmpty />}
-      valueComp={{ value: '', label: '' }}
-      buttonClassName={cx(iconButtonStyle, p_xs, readOnly ? disabledStyle : buttonStyle)}
-      entries={entries}
-    />
-  );
 }

--- a/colab-webapp/src/main/node/app/src/components/common/element/Input.tsx
+++ b/colab-webapp/src/main/node/app/src/components/common/element/Input.tsx
@@ -172,19 +172,6 @@ function Input({
   const [currentInternalValue, setCurrentInternalValue] = React.useState<string | number>('');
   const [mode, setMode] = React.useState<'DISPLAY' | 'EDIT'>('DISPLAY');
 
-  // the field can resize itself automatically
-  const updateSize = React.useCallback(() => {
-    if (autoWidth) {
-      if (inputRef.current) {
-        inputRef.current.style.width = 0 + 'px';
-        inputRef.current.style.width = inputRef.current.scrollWidth + 5 + 'px';
-        if (inputRef.current.value.length === 0) {
-          inputRef.current.style.width = inputRef.current.placeholder.length + 3 + 'ch';
-        }
-      }
-    }
-  }, [autoWidth]);
-
   // when value changes, use it as current value
   React.useEffect(() => {
     if (inputType === 'input' && inputRef.current != null) {
@@ -195,9 +182,7 @@ function Input({
     }
 
     setCurrentInternalValue(initialValue);
-
-    updateSize();
-  }, [inputType, initialValue, updateSize]);
+  }, [inputType, initialValue]);
 
   const save = React.useCallback(() => {
     if (inputType === 'input' && inputRef.current != null) {
@@ -222,12 +207,10 @@ function Input({
 
     setCurrentInternalValue(initialValue);
 
-    updateSize();
-
     if (onCancel) {
       onCancel();
     }
-  }, [inputType, inputRef, textareaRef, initialValue, updateSize, onCancel]);
+  }, [inputType, inputRef, textareaRef, initialValue, onCancel]);
 
   // const handleClickOutside = (event: Event) => {
   //   if (containerRef.current != null && !containerRef.current.contains(event.target as Node)) {
@@ -286,6 +269,24 @@ function Input({
     [saveMode, save, inputType],
   );
 
+  // the field can resize itself automatically
+  const updateSize = React.useCallback(() => {
+    if (autoWidth) {
+      if (inputRef.current) {
+        inputRef.current.style.width = 0 + 'px';
+        inputRef.current.style.width = inputRef.current.scrollWidth + 5 + 'px';
+        if (inputRef.current.value.length === 0) {
+          inputRef.current.style.width = inputRef.current.placeholder.length + 3 + 'ch';
+        }
+      }
+    }
+  }, [autoWidth]);
+
+  React.useEffect(() => {
+    // update the size when value or style change
+    updateSize();
+  }, [inputRef.current?.value, inputRef.current?.style, updateSize]);
+
   const updated = currentInternalValue !== initialValue;
 
   return (
@@ -323,7 +324,6 @@ function Input({
           onClick={stopEventPropagation}
           onDoubleClick={stopEventPropagation}
           onFocus={setEditMode}
-          onInput={updateSize}
           onChange={changeInternal}
           onKeyDown={pressEnterKey}
           onBlur={() => {

--- a/colab-webapp/src/main/node/app/src/components/common/layout/Icon.tsx
+++ b/colab-webapp/src/main/node/app/src/components/common/layout/Icon.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { MaterialIconsType } from '../../../styling/IconType';
 
 export enum IconSize {
+  xxs = '16',
   xs = '20',
   sm = '24',
   md = '40',

--- a/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/FormatDropDown.tsx
+++ b/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/FormatDropDown.tsx
@@ -219,8 +219,7 @@ export function BlockFormatDropDown({
         buttonClassName={cx(iconButtonStyle, ghostIconButtonStyle) + ' block-type'}
         buttonLabel={
           <>
-            <Icon icon={blockTypeToBlockIcon[blockType] || 'format_paragraph'} opsz={iconSize} />{' '}
-            {blockTypeToBlockName[blockType] || i18n.modules.content.textFormat.paragraph}
+            <Icon icon={blockTypeToBlockIcon[blockType] || 'format_paragraph'} opsz={iconSize} />
           </>
         }
         disabled={disabled}

--- a/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/FormatDropDown.tsx
+++ b/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/FormatDropDown.tsx
@@ -22,7 +22,7 @@ import { MaterialIconsType } from '../../../../../styling/IconType';
 import { ghostIconButtonStyle, iconButtonStyle, space_xs } from '../../../../../styling/style';
 import DropDownMenu from '../../../../common/layout/DropDownMenu';
 import Flex from '../../../../common/layout/Flex';
-import Icon from '../../../../common/layout/Icon';
+import Icon, { IconSize } from '../../../../common/layout/Icon';
 
 export const blockTypeToBlockName = {
   code: 'Code Block',
@@ -51,10 +51,12 @@ const blockTypeToBlockIcon: Record<string, MaterialIconsType> = {
 export function BlockFormatDropDown({
   editor,
   blockType,
+  iconSize = 'xs',
   disabled = false,
 }: {
   editor: LexicalEditor;
   blockType: keyof typeof blockTypeToBlockName;
+  iconSize?: keyof typeof IconSize;
   disabled?: boolean;
 }) {
   const i18n = useTranslations();
@@ -117,7 +119,7 @@ export function BlockFormatDropDown({
       label: (
         <>
           <Flex align="center" className="text">
-            <Icon color="var(--text-secondary)" opsz="xs" icon="format_paragraph" />
+            <Icon color="var(--text-secondary)" opsz={iconSize} icon="format_paragraph" />
             {i18n.modules.content.textFormat.paragraph}
           </Flex>
         </>
@@ -129,7 +131,7 @@ export function BlockFormatDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" opsz="xs" icon="format_h1" />
+            <Icon color="var(--text-secondary)" opsz={iconSize} icon="format_h1" />
             {i18n.modules.content.textFormat.heading1}
           </Flex>
         </>
@@ -141,7 +143,7 @@ export function BlockFormatDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" opsz="xs" icon="format_h2" />
+            <Icon color="var(--text-secondary)" opsz={iconSize} icon="format_h2" />
             {i18n.modules.content.textFormat.heading2}
           </Flex>
         </>
@@ -153,7 +155,7 @@ export function BlockFormatDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" opsz="xs" icon="format_h3" />
+            <Icon color="var(--text-secondary)" opsz={iconSize} icon="format_h3" />
             {i18n.modules.content.textFormat.heading3}
           </Flex>
         </>
@@ -165,7 +167,7 @@ export function BlockFormatDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" opsz="xs" icon="format_h4" />
+            <Icon color="var(--text-secondary)" opsz={iconSize} icon="format_h4" />
             {i18n.modules.content.textFormat.heading4}
           </Flex>
         </>
@@ -177,7 +179,7 @@ export function BlockFormatDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" opsz="xs" icon="format_h5" />
+            <Icon color="var(--text-secondary)" opsz={iconSize} icon="format_h5" />
             {i18n.modules.content.textFormat.heading5}
           </Flex>
         </>
@@ -189,7 +191,7 @@ export function BlockFormatDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" opsz="xs" icon="code" />
+            <Icon color="var(--text-secondary)" opsz={iconSize} icon="code" />
             {i18n.modules.content.textFormat.code}
           </Flex>
         </>
@@ -201,7 +203,7 @@ export function BlockFormatDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" opsz="xs" icon="format_quote" />
+            <Icon color="var(--text-secondary)" opsz={iconSize} icon="format_quote" />
             {i18n.modules.content.textFormat.quote}
           </Flex>
         </>
@@ -215,8 +217,12 @@ export function BlockFormatDropDown({
         value={blockType}
         entries={entries}
         buttonClassName={cx(iconButtonStyle, ghostIconButtonStyle) + ' block-type'}
-        buttonLabel={blockTypeToBlockName[blockType]}
-        icon={blockTypeToBlockIcon[blockType]}
+        buttonLabel={
+          <>
+            <Icon icon={blockTypeToBlockIcon[blockType] || 'format_paragraph'} opsz={iconSize} />{' '}
+            {blockTypeToBlockName[blockType] || i18n.modules.content.textFormat.paragraph}
+          </>
+        }
         disabled={disabled}
         title={i18n.modules.content.textFormat.formatText}
         menuIcon={'CARET'}

--- a/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/ListDropDown.tsx
+++ b/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/ListDropDown.tsx
@@ -18,7 +18,7 @@ import { MaterialIconsType } from '../../../../../styling/IconType';
 import { ghostIconButtonStyle, iconButtonStyle, space_xs } from '../../../../../styling/style';
 import DropDownMenu from '../../../../common/layout/DropDownMenu';
 import Flex from '../../../../common/layout/Flex';
-import Icon from '../../../../common/layout/Icon';
+import Icon, { IconSize } from '../../../../common/layout/Icon';
 
 export declare type ListFormatType = 'paragraph' | 'bullet' | 'number' | 'check';
 
@@ -39,10 +39,12 @@ const listTypeToListIcon: Record<string, MaterialIconsType> = {
 export default function ListDropDown({
   editor,
   disabled = false,
+  iconSize = 'xs',
   listType: listType,
 }: {
   editor: LexicalEditor;
   disabled?: boolean;
+  iconSize?: keyof typeof IconSize;
   listType: keyof typeof listTypeToListName;
 }) {
   const i18n = useTranslations();
@@ -77,7 +79,7 @@ export default function ListDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" icon="format_list_bulleted" opsz="xs" />
+            <Icon color="var(--text-secondary)" icon="format_list_bulleted" opsz={iconSize} />
             {i18n.modules.content.textFormat.bulletList}
           </Flex>
         </>
@@ -89,7 +91,7 @@ export default function ListDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" icon="format_list_numbered" opsz="xs" />
+            <Icon color="var(--text-secondary)" icon="format_list_numbered" opsz={iconSize} />
             {i18n.modules.content.textFormat.numberList}
           </Flex>
         </>
@@ -101,7 +103,7 @@ export default function ListDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" icon="checklist" opsz="xs" />
+            <Icon color="var(--text-secondary)" icon="checklist" opsz={iconSize} />
             {i18n.modules.content.textFormat.checkList}
           </Flex>
         </>
@@ -116,7 +118,7 @@ export default function ListDropDown({
         entries={entries}
         buttonClassName={cx(iconButtonStyle, ghostIconButtonStyle)}
         buttonLabel={
-          <Icon opsz="xs" icon={listTypeToListIcon[listType] || 'format_list_bulleted'} />
+          <Icon icon={listTypeToListIcon[listType] || 'format_list_bulleted'} opsz={iconSize} />
         }
         disabled={disabled}
         title={i18n.modules.content.textFormat.formatList}

--- a/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/TextAlignDropDown.tsx
+++ b/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/TextAlignDropDown.tsx
@@ -12,7 +12,7 @@ import { MaterialIconsType } from '../../../../../styling/IconType';
 import { ghostIconButtonStyle, iconButtonStyle, space_xs } from '../../../../../styling/style';
 import DropDownMenu from '../../../../common/layout/DropDownMenu';
 import Flex from '../../../../common/layout/Flex';
-import Icon from '../../../../common/layout/Icon';
+import Icon, { IconSize } from '../../../../common/layout/Icon';
 import { UPDATE_TOOLBAR_COMMAND } from './ToolbarPlugin';
 
 const elementFormatTypeToIcon: Record<string, MaterialIconsType> = {
@@ -25,10 +25,12 @@ const elementFormatTypeToIcon: Record<string, MaterialIconsType> = {
 export default function TextAlignDropDown({
   editor,
   alignment,
+  iconSize = 'xs',
   disabled = false,
 }: {
   editor: LexicalEditor;
   alignment: ElementFormatType;
+  iconSize?: keyof typeof IconSize;
   disabled?: boolean;
 }) {
   const i18n = useTranslations();
@@ -39,7 +41,7 @@ export default function TextAlignDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" icon="format_align_left" opsz="xs" />
+            <Icon color="var(--text-secondary)" icon="format_align_left" opsz={iconSize} />
             {i18n.modules.content.textFormat.leftAlign}
           </Flex>
         </>
@@ -54,7 +56,7 @@ export default function TextAlignDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" icon="format_align_center" opsz="xs" />
+            <Icon color="var(--text-secondary)" icon="format_align_center" opsz={iconSize} />
             {i18n.modules.content.textFormat.centerAlign}
           </Flex>
         </>
@@ -69,7 +71,7 @@ export default function TextAlignDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" icon="format_align_right" opsz="xs" />
+            <Icon color="var(--text-secondary)" icon="format_align_right" opsz={iconSize} />
             {i18n.modules.content.textFormat.rightAlign}
           </Flex>
         </>
@@ -84,7 +86,7 @@ export default function TextAlignDropDown({
       label: (
         <>
           <Flex align="center" gap={space_xs} className="text">
-            <Icon color="var(--text-secondary)" icon="format_align_justify" opsz="xs" />
+            <Icon color="var(--text-secondary)" icon="format_align_justify" opsz={iconSize} />
             {i18n.modules.content.textFormat.justify}
           </Flex>
         </>
@@ -102,7 +104,7 @@ export default function TextAlignDropDown({
         entries={entries}
         buttonClassName={cx(iconButtonStyle, ghostIconButtonStyle)}
         buttonLabel={
-          <Icon opsz="xs" icon={elementFormatTypeToIcon[alignment] || 'format_align_left'} />
+          <Icon icon={elementFormatTypeToIcon[alignment] || 'format_align_left'} opsz={iconSize} />
         }
         disabled={disabled}
         title={i18n.modules.content.textFormat.alignText}

--- a/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/ToolbarPlugin.tsx
+++ b/colab-webapp/src/main/node/app/src/components/documents/texteditor/plugins/ToolbarPlugin/ToolbarPlugin.tsx
@@ -81,6 +81,8 @@ export function Divider({ isHorizontal = true }: DividerProps): JSX.Element {
   return <div className={isHorizontal ? dividerStyleHorizontal : dividerStyleVertical} />;
 }
 
+const iconSize = 'xs';
+
 const toolbarStyle = cx(
   p_xs,
   css({
@@ -359,7 +361,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
     <Flex align="center" className={cx(toolbarStyle, 'toolbar')}>
       {/* <IconButton
         icon={'undo'}
-        iconSize="xs"
+        iconSize={iconSize}
         disabled={!canUndo || !isEditable}
         onClick={() => {
           activeEditor.dispatchCommand(UNDO_COMMAND, undefined);
@@ -370,7 +372,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
       />
       <IconButton
         icon={'redo'}
-        iconSize="xs"
+        iconSize={iconSize}
         disabled={!canRedo || !isEditable}
         onClick={() => {
           activeEditor.dispatchCommand(REDO_COMMAND, undefined);
@@ -382,13 +384,19 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
       <Divider /> */}
       {blockType in blockTypeToBlockName && activeEditor === editor && (
         <>
-          <BlockFormatDropDown disabled={!isEditable} blockType={blockType} editor={editor} />
+          <BlockFormatDropDown
+            disabled={!isEditable}
+            blockType={blockType}
+            editor={editor}
+            iconSize={iconSize}
+          />
           <Divider />
         </>
       )}
       <Flex direction="row">
         <IconButton
           icon={'format_bold'}
+          iconSize={iconSize}
           disabled={!isEditable}
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
@@ -399,6 +407,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
         />
         <IconButton
           icon={'format_italic'}
+          iconSize={iconSize}
           className={cx(isItalic ? 'active' : '', activeToolbarButtonStyle, ghostIconButtonStyle)}
           disabled={!isEditable}
           onClick={() => {
@@ -409,6 +418,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
         />
         <IconButton
           icon={'format_underlined'}
+          iconSize={iconSize}
           className={cx(
             isUnderline ? 'active' : '',
             activeToolbarButtonStyle,
@@ -423,6 +433,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
         />
         <IconButton
           icon={'strikethrough_s'}
+          iconSize={iconSize}
           className={cx(
             isStrikethrough ? 'active' : '',
             activeToolbarButtonStyle,
@@ -437,7 +448,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
         />
         <IconButton
           icon={'replay'}
-          iconSize="xs"
+          iconSize={iconSize}
           className={cx(activeToolbarButtonStyle, ghostIconButtonStyle)}
           disabled={!isEditable}
           onClick={clearFormatting}
@@ -470,7 +481,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
           title={i18n.modules.content.textFormat.colorText}
           buttonLabel={
             <Icon
-              opsz={'xs'}
+              opsz={iconSize}
               icon={'format_color_text'}
               color={textColor === '#000000' ? 'inherit' : textColor}
             />
@@ -500,7 +511,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
           title={i18n.modules.content.textFormat.highlightText}
           buttonLabel={
             <Icon
-              opsz={'xs'}
+              opsz={iconSize}
               icon={'format_color_fill'}
               color={bgColor === '#ffffff' ? 'inherit' : bgColor}
             />
@@ -512,10 +523,10 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
         <Flex direction="row">
           <Divider />
           <>
-            <TextAlignDropDown editor={editor} alignment={alignment} />
+            <TextAlignDropDown editor={editor} alignment={alignment} iconSize={iconSize} />
           </>
           <>
-            <ListDropDown editor={editor} listType={listType} />
+            <ListDropDown editor={editor} listType={listType} iconSize={iconSize} />
           </>
         </Flex>
       )}
@@ -523,7 +534,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
         <Divider />
         <IconButton
           icon={'link'}
-          iconSize="xs"
+          iconSize={iconSize}
           className={cx(isLink ? 'active' : '', activeToolbarButtonStyle, ghostIconButtonStyle)}
           disabled={!isEditable}
           onClick={insertLink}
@@ -533,7 +544,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
       </Flex>
       {/* <IconButton
         icon={'move_down'}
-        iconSize="xs"
+        iconSize={iconSize}
         className={cx(activeToolbarButtonStyle, ghostIconButtonStyle)}
         disabled={!isEditable}
         onClick={() => {
@@ -548,7 +559,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
         <Divider />
         <IconButton
           icon={'image'}
-          iconSize="xs"
+          iconSize={iconSize}
           className={cx('toolbar-item spaced ' + activeToolbarButtonStyle, ghostIconButtonStyle)}
           disabled={!isEditable}
           onClick={() => {
@@ -561,7 +572,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
         />
         <IconButton
           icon={'description'}
-          iconSize="xs"
+          iconSize={iconSize}
           className={cx('toolbar-item spaced ', activeToolbarButtonStyle, ghostIconButtonStyle)}
           disabled={!isEditable}
           onClick={() => {
@@ -578,7 +589,7 @@ export default function ToolbarPlugin(docOwnership: DocumentOwnership) {
         />
         <IconButton
           icon={'table'}
-          iconSize="xs"
+          iconSize={iconSize}
           className={cx(activeToolbarButtonStyle, ghostIconButtonStyle)}
           disabled={!isEditable}
           onClick={() => {

--- a/colab-webapp/src/main/node/app/src/components/projects/listView/CardView.tsx
+++ b/colab-webapp/src/main/node/app/src/components/projects/listView/CardView.tsx
@@ -16,15 +16,15 @@ import { useAppDispatch } from '../../../store/hooks';
 import { useDefaultVariant } from '../../../store/selectors/cardSelector';
 import { heading_sm, space_sm } from '../../../styling/style';
 import StatusDropDown from '../../cards/StatusDropDown';
-import IconButton from '../../common/element/IconButton';
+import DeletionStatusIndicator from '../../common/element/DeletionStatusIndicator';
 import InlineLoading from '../../common/element/InlineLoading';
 import { DiscreetInput } from '../../common/element/Input';
 import Collapsible from '../../common/layout/Collapsible';
 import Flex from '../../common/layout/Flex';
+import Icon from '../../common/layout/Icon';
 import { DocumentOwnership } from '../../documents/documentCommonType';
 import TextEditorWrapper from '../../documents/texteditor/TextEditorWrapper';
 import ListView from './ListView';
-import DeletionStatusIndicator from '../../common/element/DeletionStatusIndicator';
 
 interface CardViewProps {
   card: Card;
@@ -100,16 +100,14 @@ export default function CardView({ card, id }: CardViewProps): JSX.Element {
                         inputDisplayClassName={heading_sm}
                         autoWidth={true}
                       />
-                      <IconButton
-                        icon={variant.frozen ? 'lock' : 'lock_open'}
-                        title={i18n.modules.card.infos.cardLocked}
-                        color={'var(--gray-400)'}
-                        onClick={() =>
-                          dispatch(API.updateCardContent({ ...variant, frozen: !variant.frozen }))
-                        }
-                        kind="ghost"
-                        className={css({ padding: space_sm, background: 'none' })}
-                      />
+                      {variant.frozen /* display only if is frozen */ && (
+                        <Icon
+                          icon={'lock'}
+                          title={i18n.modules.card.infos.cardLocked}
+                          color={'var(--gray-400)'}
+                          className={css({ padding: space_sm, background: 'none' })}
+                        />
+                      )}
                       <StatusDropDown
                         value={variant.status}
                         readOnly={variant.frozen}

--- a/colab-webapp/src/main/node/app/src/i18n/en.ts
+++ b/colab-webapp/src/main/node/app/src/i18n/en.ts
@@ -453,6 +453,9 @@ export const en = {
       showCardType: 'Show theme description',
       editCompletion: 'Edit card completion',
       action: {
+        lock: 'Lock',
+        unlock: 'Unlock',
+        changeStatus: 'Change status',
         chooseACardType: 'What theme is your card about?',
         createAType: 'Create a theme',
         removeTheType: 'Remove the theme',
@@ -487,8 +490,7 @@ export const en = {
       },
       infos: {
         createFirstCard: 'Create the first card',
-        cardLocked: 'Card is locked. Click to free it for edits.',
-        cardUnlocked: 'Card is free for edits. Click to lock.',
+        cardLocked: 'Card is locked. Unlock it first for edition',
         lockingCard: 'Locking sets to read-only.',
         noDeliverable: 'No deliverable available',
         completionModeInfo:

--- a/colab-webapp/src/main/node/app/src/i18n/en.ts
+++ b/colab-webapp/src/main/node/app/src/i18n/en.ts
@@ -477,6 +477,9 @@ export const en = {
         hideToolbox: 'Hide toolbox',
         toggleToolbox: 'Toggle toolbox',
         fullScreen: 'Full screen mode',
+        contentOnly: 'Display text only',
+        split: 'Display text and cards',
+        cardsOnly: 'Display cards only',
       },
       // navigation: {
       //   toggleViewZoomToEdit: 'Edit card',

--- a/colab-webapp/src/main/node/app/src/i18n/fr.ts
+++ b/colab-webapp/src/main/node/app/src/i18n/fr.ts
@@ -462,6 +462,9 @@ export const fr: ColabTranslations = {
       showCardType: 'Afficher les informations du thème',
       editCompletion: "Éditer l'avancement",
       action: {
+        lock: 'Verrouiller',
+        unlock: 'Déverouiller',
+        changeStatus: 'Changer le status',
         chooseACardType: 'Quel est le thème de votre carte ?',
         createAType: 'Créer un thème',
         removeTheType: 'Enlever le thème',
@@ -496,8 +499,7 @@ export const fr: ColabTranslations = {
       },
       infos: {
         createFirstCard: 'Créer la première carte',
-        cardLocked: "Carte verrouillée. Cliquez pour la rendre libre d'être modifiée.",
-        cardUnlocked: "Carte libre d'être modifiée. Cliquez pour la verrouiller.",
+        cardLocked: 'Carte verrouillée. Déverrouillez-la pour la modifier',
         lockingCard: 'Le verrouillage passe en lecture seule.',
         noDeliverable: 'Aucun livrable disponible',
         completionModeInfo:

--- a/colab-webapp/src/main/node/app/src/i18n/fr.ts
+++ b/colab-webapp/src/main/node/app/src/i18n/fr.ts
@@ -487,6 +487,9 @@ export const fr: ColabTranslations = {
         showToolbox: 'Afficher la boîte à outils',
         hideToolbox: 'Masquer la boîte à outils',
         fullScreen: 'Mode plein écran',
+        contentOnly: 'Afficher le texte uniquement',
+        split: 'Afficher le texte et les cartes',
+        cardsOnly: 'Afficher les cartes uniquement',
       },
       // navigation: {
       //   toggleViewZoomToEdit: 'Editer la carte',


### PR DESCRIPTION
- status display
- lock display
- edit card action available in drop down menu
- buttons to split the card editor between text part and sub-cards part
- try to fix font for Safari
- fix project name field size
- harmonise the icon size of the text editor toolbar
- show only icon of text format in the text editor